### PR TITLE
Add basic road damage detection endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,6 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
+
+from backend.damage_detection import decode_image, detect_damage
 
 app = Flask(__name__)
 
@@ -10,5 +12,18 @@ def index():
 def health_check():
     return jsonify({'status': 'ok'})
 
+
+@app.route('/detect_road_damage', methods=['POST'])
+def detect_road_damage():
+    data = request.get_json(force=True)
+    if not data or 'image' not in data:
+        return jsonify({'error': 'image field required'}), 400
+    try:
+        image = decode_image(data['image'])
+        boxes = detect_damage(image)
+        return jsonify({'boxes': boxes})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, port=5005)

--- a/backend/damage_detection.py
+++ b/backend/damage_detection.py
@@ -1,0 +1,31 @@
+import base64
+from io import BytesIO
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image
+
+
+def decode_image(base64_str: str) -> np.ndarray:
+    image_data = base64.b64decode(base64_str)
+    image = Image.open(BytesIO(image_data)).convert('RGB')
+    return cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
+
+
+def detect_damage(image: np.ndarray) -> List[Tuple[int, int, int, int]]:
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    edges = cv2.Canny(blurred, 50, 150)
+    dilated = cv2.dilate(edges, np.ones((3, 3), np.uint8), iterations=1)
+    contours, _ = cv2.findContours(dilated, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    boxes = []
+    for cnt in contours:
+        x, y, w, h = cv2.boundingRect(cnt)
+        if w * h > 500:  # simple area threshold
+            boxes.append((int(x), int(y), int(w), int(h)))
+    return boxes
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 Flask>=3.0
+opencv-python>=4.0
+Pillow>=10.0
+numpy>=1.20


### PR DESCRIPTION
## Summary
- add simple OpenCV-based road damage detector
- expose `/detect_road_damage` endpoint
- include new Python dependencies

## Testing
- `python -m py_compile backend/app.py backend/damage_detection.py`
- `python backend/app.py`'s test client returns detection results

------
https://chatgpt.com/codex/tasks/task_e_685421a26f88832d96ada15ac88c739e