### PR TITLE
Add React frontend with Vanta background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+node_modules/

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,121 @@
+const { useState, useEffect, useRef } = React;
+
+function useVanta() {
+  const vantaRef = useRef(null);
+  useEffect(() => {
+    let effect = window.VANTA.NET({
+      el: vantaRef.current,
+      mouseControls: true,
+      touchControls: true,
+      color: 0xff3f81,
+      backgroundColor: 0x0a0a0a
+    });
+    return () => {
+      if (effect) effect.destroy();
+    };
+  }, []);
+  return vantaRef;
+}
+
+function DamageDetector() {
+  const [image, setImage] = useState(null);
+  const [boxes, setBoxes] = useState([]);
+  const [error, setError] = useState(null);
+
+  const handleChange = e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => setImage(ev.target.result.split(',')[1]);
+    reader.readAsDataURL(file);
+  };
+
+  const handleSubmit = async () => {
+    if (!image) return;
+    try {
+      const res = await fetch('/detect_road_damage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Error');
+      setBoxes(data.boxes);
+      setError(null);
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl font-bold mb-4">Road Damage Detection</h1>
+      <input type="file" accept="image/*" onChange={handleChange} className="mb-2" />
+      <button onClick={handleSubmit} className="bg-blue-500 text-white px-4 py-2 rounded">Send</button>
+      {error && <p className="text-red-400 mt-2">{error}</p>}
+      <div className="mt-4">
+        {boxes.map((b,i)=>(<div key={i}>Box: {b.join(', ')}</div>))}
+      </div>
+    </div>
+  );
+}
+
+function VideoFrameExtractor() {
+  const [videoURL, setVideoURL] = useState(null);
+  const [frames, setFrames] = useState([]);
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+
+  const handleFile = e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    setVideoURL(URL.createObjectURL(file));
+  };
+
+  const captureFrame = () => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) return;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const url = canvas.toDataURL('image/png');
+    setFrames(f => [...f, url]);
+  };
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl font-bold mb-4">Video Frame Extractor</h1>
+      <input type="file" accept="video/*" onChange={handleFile} className="mb-2" />
+      {videoURL && (
+        <div>
+          <video src={videoURL} controls ref={videoRef} className="w-full max-w-md mb-2" />
+          <button onClick={captureFrame} className="bg-green-500 px-4 py-2 rounded">Capture Frame</button>
+          <canvas ref={canvasRef} className="hidden" />
+        </div>
+      )}
+      <div className="flex flex-wrap mt-4 gap-2">
+        {frames.map((f,i)=>(<img key={i} src={f} alt={`frame-${i}`} className="w-32 h-32 object-cover"/>))}
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const [page, setPage] = useState('detect');
+  const vantaRef = useVanta();
+  return (
+    <div ref={vantaRef} className="w-full h-full overflow-auto">
+      <div className="max-w-2xl mx-auto bg-black bg-opacity-50 min-h-screen">
+        <nav className="flex gap-4 p-4 text-white">
+          <button onClick={()=>setPage('detect')} className="underline">Damage Detector</button>
+          <button onClick={()=>setPage('video')} className="underline">Video Extractor</button>
+        </nav>
+        {page==='detect'?<DamageDetector/>:<VideoFrameExtractor/>}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cycle Tourism Frontend</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vanta@latest/dist/vanta.net.min.js"></script>
+    <style>
+        body,html,#vanta-bg{height:100%;margin:0;}
+    </style>
+</head>
+<body>
+<div id="vanta-bg" class="flex items-center justify-center">
+    <div id="root" class="w-full"></div>
+</div>
+<script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,44 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -198,3 +198,18 @@ python backend/app.py
 ```
 
 `/`路線でAPIの結果がJSONで返ります。`/health`路線はヘルスチェック用です。
+
+## フロントエンド (React)
+
+`frontend` ディレクトリには Tailwind CSS と Vanta.js を利用した簡易 React アプリを配置しています。画像をアップロードして道路損傷検知結果を表示するページと、動画からフレームを抜き出すページを切り替えて利用できます。
+
+### 起動方法
+
+以下のように静的サーバを立ち上げてアクセスしてください。
+
+```bash
+cd frontend
+python -m http.server 8000
+```
+
+ブラウザで `http://localhost:8000` を開くとアプリが表示されます。


### PR DESCRIPTION
## Summary
- add a small React frontend using Tailwind CSS and Vanta.js
- include an image upload form that sends the image to `/detect_road_damage`
- add a page to extract frames from a video
- update documentation with frontend usage instructions
- ignore `node_modules` via `.gitignore`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68542562a30c832d87012441a9b6bad2