### PR TITLE
Add unit tests for backend services and routes

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -4,7 +4,6 @@ from flask import Flask
 from backend.routes import ALL_BLUEPRINTS
 
 
-
 def create_app() -> Flask:
     app = Flask(__name__)
 

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,7 +1,5 @@
-
 from .index import bp as index_bp
 from .health import bp as health_bp
 from .detect import bp as damage_bp
 
 ALL_BLUEPRINTS = [index_bp, health_bp, damage_bp]
-

--- a/readme.md
+++ b/readme.md
@@ -243,3 +243,12 @@ python backend/object_detection_pipeline.py train /path/to/dataset output_dir --
 python backend/object_detection_pipeline.py eval output_dir/model.pt /path/to/val_dataset
 ```
 
+
+## テストの実行
+
+ユニットテストは `pytest` で実行できます。
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from backend import create_app
+
+
+def test_health_endpoint():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_index_endpoint():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"message": "Cycle Tourism Platform API"}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,39 @@
+import base64
+from io import BytesIO
+import os
+import sys
+
+import cv2
+import numpy as np
+from PIL import Image
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from backend.services.damage_detection import decode_image, detect_damage
+
+
+def _encode_image(arr: np.ndarray) -> str:
+    im = Image.fromarray(cv2.cvtColor(arr, cv2.COLOR_BGR2RGB))
+    buf = BytesIO()
+    im.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def test_decode_image_roundtrip():
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    encoded = _encode_image(image)
+    decoded = decode_image(encoded)
+    assert decoded.shape == image.shape
+    assert decoded.dtype == image.dtype
+
+
+def test_detect_damage_square():
+    image = np.zeros((100, 100, 3), dtype=np.uint8)
+    cv2.rectangle(image, (20, 20), (40, 40), (255, 255, 255), -1)
+    boxes = detect_damage(image)
+    assert boxes, "no boxes returned"
+    x, y, w, h = boxes[0]
+    assert 15 <= x <= 25
+    assert 15 <= y <= 25
+    assert 20 <= w <= 30
+    assert 20 <= h <= 30


### PR DESCRIPTION
## Summary
- add pytest unit tests for service helpers and routes
- format backend modules with black
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560d35752c832dad9de43a0202125d